### PR TITLE
Kernel dev

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ sc_kernel
 :Author:
     bsnacks000
 
-:Curent Version: 0.0.0
+:Curent Version: version = 0.0.1
 
 A simple jupyter wrapper kernel for SuperCollider. It uses pexpect's REPLWrapper
 to communicate to spawn and send commands over an sclang process.

--- a/sc_kernel/__init__.py
+++ b/sc_kernel/__init__.py
@@ -1,1 +1,1 @@
-__version__='0.0.0'
+__version__='__version__ = '0.0.1''

--- a/sc_kernel/__main__.py
+++ b/sc_kernel/__main__.py
@@ -1,6 +1,4 @@
+from ipykernel.kernelapp import IPKernelApp
+from .kernel import SuperColliderKernel
 
-def main():
-    pass
-
-if __name__ == '__main__':
-    main()
+IPKernelApp.launch_instance(kernel_class=SuperColliderKernel)

--- a/sc_kernel/install.py
+++ b/sc_kernel/install.py
@@ -1,0 +1,38 @@
+from __future__ import (print_function, division, absolute_import, unicode_literals)
+from builtins import *
+import click
+import json
+import os
+import sys
+
+from jupyter_client.kernelspec import KernelSpecManageer
+from IPython.utils.tempdir import TemporaryDirectory
+
+'''
+This module contains the command line utility to install the kernel spec.
+'''
+
+
+# define kernel spec here
+kernel_json = { "argv":[sys.executable, "-m", "sc_kernel", "-f", "{connection_file}"],
+    "display_name":"SuperCollider"m
+    "language": "sclang",
+    "env": {"PS1":"sc3>"}
+}
+
+def install_kernel_spec(user=True, prefix=None):
+    with TemporaryDirectory as td:
+        with open(os.path.join(td, 'kernel.json'), 'w') as f:
+            json.dump(kernel_json, f, sort_keys=True)
+        print('Installing IPython kernel spec')
+        KernelSpecManager().install_kernel_spec(td, 'supercollider', user=user, replace=True, prefix=prefix)
+
+@click.command()
+def main():
+    #TODO add install options - installs to user directory with sys.prefix (virtualenv)
+    user = True
+    prefix = sys.prefix
+    install_kernel_spec(user=user, prefix=prefix)
+
+if __name__ == '__main__':
+    main()

--- a/sc_kernel/kernel.py
+++ b/sc_kernel/kernel.py
@@ -1,0 +1,51 @@
+
+from __future__ import (print_function, division, absolute_import, unicode_literals)
+
+from builtins import *
+
+from ipykernel.kernelbase import Kernel
+from pexpect import replwrap
+import pexpect
+import signal
+
+
+class SuperColliderKernel(Kernel):
+    ''' This kernel is an adaptation from the ipykernel docs and the
+     bash_kernel example by takluyver
+    '''
+
+    implementation = 'SuperCollider'
+    implementation_version = '0.0.0'
+    language_info = {
+        'name': 'sclang',
+        'mimetype': 'text/x-sclang',
+        'file_extension': '.scd'
+    }
+
+    def __init__(self, **kwargs):
+        super(SuperColliderKernel).__init__(**kwargs)
+        self._init_sc()
+
+    def _init_sc(self):
+        ''' initialize the sc repl wrapper class'''
+
+        # NOTE this is pretty simple for now, need to check out the subprocess interupt
+        self.scwrapper = replwrap.REPLWrapper('sclang', u'sc3>', None) # cretes the child process
+
+    def do_execute(self, code, silent, store_history=True, allow_stdin=False):
+        ''' executes the code in the cell by passing to wrapper.run_command
+        '''
+        if not code.strip():
+            return {'status': 'ok', 'execution_count': self.execution_count,
+                    'payload': [], 'user_expressions': {}}
+
+        #NOTE needs error handling and keyboard interupt handling 
+        self.scwrapper.run_command(code.rstrip(), timeout=None)
+
+        if not silent:
+            output = self.scwrapper.child.before  # this gets the last streamed output from the child process
+            stream_content = {'name': 'stdout', 'text': output}
+            self.send_response(self.iopub_socket, 'stream', stream_content)
+
+        return {'status': 'ok', 'execution_count': self.execution_count,
+                    'payload': [], 'user_expressions': {}}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.0
+current_version = 0.0.1
 commit = True
 tag = True
 
@@ -17,3 +17,4 @@ replace = __version__ = '{new_version}'
 
 [bdist_wheel]
 universal = 1
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.3
+current_version = 0.0.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ requirements=[
     'Click',
     'pexpect==4.3.1',
     'ptyprocess==0.5.2',
-    'future'
+    'future',
+    'ipykernel'
 ]
 test_requirements =[
     'nose'
@@ -28,6 +29,7 @@ setup(
         'Development Status :: 3 - Alpha'
         'Intended Audience :: SuperCollider users, Developers'
         'License :: MIT License'
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6'
     ]

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_requirements =[
 
 setup(
     name='sc_kernel',
-    version='0.0.0',
+    version='0.0.1',
     description='A basic IPython kernel REPLwrapper for SuperCollider',
     long_description=long_description,
     url=''


### PR DESCRIPTION
a basic sc kernel is working in jupyter console after installation.

However without proper interrupt handling the jupyter console cannot be exited properly and the child process is not killed if an error happens in ipykernel. This probably needs to be implemented in the do_execute and _init_sc methods, similar to the bash_kernel example 